### PR TITLE
Encrypt API responses in network traffic

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:3000/api
+VITE_ENCRYPT_RESPONSES=true
+VITE_API_ENCRYPTION_KEY=same_32_byte_hex_key_as_server_API_ENCRYPTION_KEY

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { isEncryptedPayload, decryptPayload, encryptionEnabled } from '../lib/crypto';
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api',
@@ -17,7 +18,12 @@ apiClient.interceptors.request.use((config) => {
 });
 
 apiClient.interceptors.response.use(
-  (response) => response,
+  async (response) => {
+    if (encryptionEnabled && isEncryptedPayload(response.data)) {
+      response.data = await decryptPayload(response.data);
+    }
+    return response;
+  },
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem('token');

--- a/client/src/lib/crypto.ts
+++ b/client/src/lib/crypto.ts
@@ -1,0 +1,70 @@
+const ENABLED = import.meta.env.VITE_ENCRYPT_RESPONSES === 'true';
+const KEY_HEX = import.meta.env.VITE_API_ENCRYPTION_KEY as string | undefined;
+
+let cachedKey: CryptoKey | null = null;
+
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  const buf = new ArrayBuffer(hex.length / 2);
+  const bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64);
+  const buf = new ArrayBuffer(binary.length);
+  const bytes = new Uint8Array(buf);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function getKey(): Promise<CryptoKey> {
+  if (cachedKey) return cachedKey;
+  if (!KEY_HEX) throw new Error('VITE_API_ENCRYPTION_KEY is not set');
+  const keyBytes = hexToBytes(KEY_HEX);
+  cachedKey = await window.crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'AES-GCM' },
+    false,
+    ['decrypt']
+  );
+  return cachedKey;
+}
+
+export function isEncryptedPayload(data: unknown): data is { iv: string; data: string; tag: string } {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'iv' in data &&
+    'data' in data &&
+    'tag' in data
+  );
+}
+
+export async function decryptPayload(payload: { iv: string; data: string; tag: string }): Promise<unknown> {
+  const key = await getKey();
+  const iv = base64ToBytes(payload.iv);
+  const ciphertext = base64ToBytes(payload.data);
+  const tag = base64ToBytes(payload.tag);
+
+  // Web Crypto API expects ciphertext + auth tag concatenated
+  const combinedBuf = new ArrayBuffer(ciphertext.length + tag.length);
+  const combined = new Uint8Array(combinedBuf);
+  combined.set(ciphertext);
+  combined.set(tag, ciphertext.length);
+
+  const decrypted = await window.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    combined
+  );
+
+  return JSON.parse(new TextDecoder().decode(decrypted));
+}
+
+export { ENABLED as encryptionEnabled };

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -12,7 +12,6 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/server/.env.example
+++ b/server/.env.example
@@ -11,6 +11,10 @@ DB_PASSWORD=yourpassword
 # JWT
 JWT_SECRET=change_this_to_a_long_random_string
 
+# Response encryption (set both to true and provide a matching 32-byte hex key on client too)
+ENCRYPT_RESPONSES=true
+API_ENCRYPTION_KEY=generate_with_node_crypto_randomBytes_32_hex
+
 # Email (Nodemailer) — leave blank to disable email delivery in development
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,11 +10,13 @@ import reportRoutes from './routes/reports';
 import barcodeRoutes from './routes/barcode';
 import settingsRoutes from './routes/settings';
 import { generalApiRateLimit } from './middleware/rateLimit';
+import { encryptResponse } from './middleware/encrypt';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use(encryptResponse);
 
 // Skip rate limiting in test environment to avoid interference with test assertions
 if (process.env.NODE_ENV !== 'test') {

--- a/server/src/middleware/encrypt.ts
+++ b/server/src/middleware/encrypt.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+
+export function encryptResponse(req: Request, res: Response, next: NextFunction) {
+  const enabled = process.env.ENCRYPT_RESPONSES === 'true';
+  const keyHex = process.env.API_ENCRYPTION_KEY ?? '';
+
+  if (!enabled || process.env.NODE_ENV === 'test' || !keyHex) {
+    return next();
+  }
+
+  const originalJson = res.json.bind(res);
+
+  res.json = function (body: any): Response {
+    const key = Buffer.from(keyHex, 'hex');
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+
+    const plaintext = JSON.stringify(body);
+    const encrypted = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    return originalJson({
+      iv: iv.toString('base64'),
+      data: encrypted.toString('base64'),
+      tag: tag.toString('base64'),
+    });
+  };
+
+  next();
+}


### PR DESCRIPTION
Adds AES-256-GCM response encryption middleware on the server and a matching decryption interceptor on the client. Toggled via ENCRYPT_RESPONSES and VITE_ENCRYPT_RESPONSES env vars.

Also removes deprecated baseUrl from client tsconfig.