### PR TITLE
Add Twilio SMS integration for OTP delivery and admin configuration

### DIFF
--- a/OR Tracking API.postman_collection.json
+++ b/OR Tracking API.postman_collection.json
@@ -2300,6 +2300,123 @@
           "response": []
         },
         {
+          "name": "Get Twilio Config",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Returns config', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.config).to.have.property('twilio_account_sid');",
+                  "  pm.expect(json.config).to.have.property('twilio_from');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{token}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/settings/twilio",
+              "host": ["{{baseUrl}}"],
+              "path": ["settings", "twilio"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Twilio Config",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": ["pm.test('Status 200', () => pm.response.to.have.status(200));"],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"twilio_account_sid\": \"ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",\n  \"twilio_auth_token\": \"your_auth_token\",\n  \"twilio_from\": \"+1234567890\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/settings/twilio",
+              "host": ["{{baseUrl}}"],
+              "path": ["settings", "twilio"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Test Twilio Credentials",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200 or 400', () => {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Authorization", "value": "Bearer {{token}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/settings/twilio/test",
+              "host": ["{{baseUrl}}"],
+              "path": ["settings", "twilio", "test"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Send Twilio Test SMS",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200 or 400', () => {",
+                  "  pm.expect(pm.response.code).to.be.oneOf([200, 400]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"to\": \"+447700900001\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/settings/twilio/send-test",
+              "host": ["{{baseUrl}}"],
+              "path": ["settings", "twilio", "send-test"]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Send Resend Test Email",
           "event": [
             {
@@ -2340,6 +2457,41 @@
                 "resend",
                 "send-test"
               ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Health Check",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Returns OK', () => {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.status).to.equal('OK');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["health"]
             }
           },
           "response": []

--- a/client/src/api/settings.ts
+++ b/client/src/api/settings.ts
@@ -14,6 +14,12 @@ export interface ResendConfig {
   resend_from: string;
 }
 
+export interface TwilioConfig {
+  twilio_account_sid: string;
+  twilio_auth_token: string;
+  twilio_from: string;
+}
+
 export const settingsAPI = {
   getSmtp: async (): Promise<SmtpConfig> => {
     const response = await apiClient.get('/settings/smtp');
@@ -43,5 +49,22 @@ export const settingsAPI = {
 
   sendTestEmail: async (to: string): Promise<void> => {
     await apiClient.post('/settings/resend/send-test', { to }, { timeout: 15_000 });
+  },
+
+  getTwilio: async (): Promise<TwilioConfig> => {
+    const response = await apiClient.get('/settings/twilio');
+    return response.data.config;
+  },
+
+  updateTwilio: async (config: Partial<TwilioConfig>): Promise<void> => {
+    await apiClient.put('/settings/twilio', config);
+  },
+
+  testTwilio: async (): Promise<void> => {
+    await apiClient.post('/settings/twilio/test', {}, { timeout: 15_000 });
+  },
+
+  sendTestSms: async (to: string): Promise<void> => {
+    await apiClient.post('/settings/twilio/send-test', { to }, { timeout: 15_000 });
   },
 };

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { reportsAPI, DailySummary, StageDurationRow, DateRangeRow, AuditLogRow } from '@/api/reports';
-import { settingsAPI, SmtpConfig, ResendConfig } from '@/api/settings';
+import { settingsAPI, SmtpConfig, ResendConfig, TwilioConfig } from '@/api/settings';
 import {
   PieChart, Pie, Cell, Tooltip, ResponsiveContainer,
   BarChart, Bar, XAxis, YAxis, CartesianGrid,
@@ -126,6 +126,21 @@ export const AdminDashboard: React.FC = () => {
   const [resendSendingTest, setResendSendingTest] = useState(false);
   const [resendSendTestResult, setResendSendTestResult] = useState<'ok' | 'fail' | null>(null);
   const [resendSendTestError, setResendSendTestError] = useState('');
+
+  // Settings: Twilio form
+  const emptyTwilioForm: TwilioConfig = { twilio_account_sid: '', twilio_auth_token: '', twilio_from: '' };
+  const [twilioForm, setTwilioForm] = useState<TwilioConfig>(emptyTwilioForm);
+  const [twilioLoading, setTwilioLoading] = useState(false);
+  const [twilioSaving, setTwilioSaving] = useState(false);
+  const [twilioTesting, setTwilioTesting] = useState(false);
+  const [twilioSaveError, setTwilioSaveError] = useState('');
+  const [twilioSaveSuccess, setTwilioSaveSuccess] = useState(false);
+  const [twilioTestResult, setTwilioTestResult] = useState<'ok' | 'fail' | null>(null);
+  const [twilioTestError, setTwilioTestError] = useState('');
+  const [twilioTestPhone, setTwilioTestPhone] = useState('');
+  const [twilioSendingTest, setTwilioSendingTest] = useState(false);
+  const [twilioSendTestResult, setTwilioSendTestResult] = useState<'ok' | 'fail' | null>(null);
+  const [twilioSendTestError, setTwilioSendTestError] = useState('');
 
   // Settings: stages management
   const [settingsStages, setSettingsStages] = useState<StageConfig[]>([]);
@@ -253,6 +268,11 @@ export const AdminDashboard: React.FC = () => {
       .then((cfg) => setSmtpForm(cfg))
       .catch(() => {})
       .finally(() => setSmtpLoading(false));
+    setTwilioLoading(true);
+    settingsAPI.getTwilio()
+      .then((cfg) => setTwilioForm(cfg))
+      .catch(() => {})
+      .finally(() => setTwilioLoading(false));
   }, [section]);
 
   const openAddStage = () => {
@@ -1695,7 +1715,7 @@ export const AdminDashboard: React.FC = () => {
                 <div className="px-5 py-4 border-b border-slate-100 flex items-center justify-between">
                   <div>
                     <h2 className="font-semibold text-slate-800">Notifications</h2>
-                    <p className="text-xs text-slate-400 mt-0.5">Resend API settings for family email notifications</p>
+                    <p className="text-xs text-slate-400 mt-0.5">Email and SMS settings for family notifications</p>
                   </div>
                   {notifConfig !== null && (
                     <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${notifConfig.emailConfigured ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'}`}>
@@ -1935,19 +1955,154 @@ export const AdminDashboard: React.FC = () => {
                     )}
                   </div>
 
-                  {notifConfig !== null && notifConfig.smsConfigured !== undefined && (
-                    <div className={`mt-6 rounded-xl border p-4 ${notifConfig.smsConfigured ? 'border-emerald-200 bg-emerald-50' : 'border-slate-200 bg-slate-50'}`}>
-                      <div className="flex items-center gap-2">
-                        {notifConfig.smsConfigured
-                          ? <CheckCircle2 className="h-4 w-4 text-emerald-600 shrink-0" />
-                          : <AlertCircle className="h-4 w-4 text-slate-400 shrink-0" />
-                        }
-                        <span className={`text-sm font-semibold ${notifConfig.smsConfigured ? 'text-emerald-700' : 'text-slate-500'}`}>
-                          SMS — {notifConfig.smsConfigured ? 'configured via Twilio env vars' : 'not configured (set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER)'}
+                  {/* Twilio SMS */}
+                  <div className="pt-6 border-t border-slate-100">
+                    <div className="flex items-center justify-between mb-4">
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide">SMS notifications (Twilio)</p>
+                      {notifConfig !== null && notifConfig.smsConfigured !== undefined && (
+                        <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${notifConfig.smsConfigured ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'}`}>
+                          {notifConfig.smsConfigured
+                            ? <CheckCircle2 className="h-3.5 w-3.5" />
+                            : <AlertCircle className="h-3.5 w-3.5" />
+                          }
+                          {notifConfig.smsConfigured ? 'SMS active' : 'SMS not configured'}
                         </span>
-                      </div>
+                      )}
                     </div>
-                  )}
+                    {twilioLoading ? (
+                      <div className="flex items-center justify-center py-4">
+                        <Loader2 className="h-5 w-5 animate-spin text-slate-300" />
+                      </div>
+                    ) : (
+                      <form
+                        onSubmit={async (e) => {
+                          e.preventDefault();
+                          setTwilioSaving(true);
+                          setTwilioSaveError('');
+                          setTwilioSaveSuccess(false);
+                          setTwilioTestResult(null);
+                          try {
+                            await settingsAPI.updateTwilio(twilioForm);
+                            setTwilioSaveSuccess(true);
+                            reportsAPI.getNotificationConfig().then(setNotifConfig).catch(() => {});
+                            setTimeout(() => setTwilioSaveSuccess(false), 3000);
+                          } catch (err: any) {
+                            setTwilioSaveError(err?.response?.data?.error ?? 'Failed to save');
+                          } finally {
+                            setTwilioSaving(false);
+                          }
+                        }}
+                        className="space-y-4"
+                      >
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                          <div className="space-y-1 sm:col-span-2">
+                            <label className="text-sm font-medium text-slate-700">Account SID</label>
+                            <input
+                              value={twilioForm.twilio_account_sid}
+                              onChange={(e) => setTwilioForm({ ...twilioForm, twilio_account_sid: e.target.value })}
+                              placeholder="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:bg-white transition-all font-mono"
+                            />
+                            <p className="text-xs text-slate-400">Found on your Twilio Console dashboard</p>
+                          </div>
+                          <div className="space-y-1 sm:col-span-2">
+                            <label className="text-sm font-medium text-slate-700">Auth token</label>
+                            <input
+                              type="password"
+                              value={twilioForm.twilio_auth_token}
+                              onChange={(e) => setTwilioForm({ ...twilioForm, twilio_auth_token: e.target.value })}
+                              placeholder={notifConfig?.smsConfigured ? 'Leave blank to keep existing' : 'Your Twilio auth token'}
+                              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:bg-white transition-all font-mono"
+                            />
+                          </div>
+                          <div className="space-y-1 sm:col-span-2">
+                            <label className="text-sm font-medium text-slate-700">From number</label>
+                            <input
+                              value={twilioForm.twilio_from}
+                              onChange={(e) => setTwilioForm({ ...twilioForm, twilio_from: e.target.value })}
+                              placeholder="+441234567890"
+                              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:bg-white transition-all"
+                            />
+                            <p className="text-xs text-slate-400">Your Twilio phone number in E.164 format</p>
+                          </div>
+                        </div>
+
+                        {twilioSaveError && <p className="text-xs text-red-600">{twilioSaveError}</p>}
+                        {twilioSaveSuccess && <p className="text-xs text-emerald-600">Settings saved.</p>}
+                        {twilioTestResult === 'ok' && <p className="text-xs text-emerald-600">Credentials are valid.</p>}
+                        {twilioTestResult === 'fail' && <p className="text-xs text-red-600">Failed: {twilioTestError}</p>}
+
+                        <div className="flex items-center gap-3 pt-1">
+                          <button
+                            type="submit"
+                            disabled={twilioSaving}
+                            className="px-4 py-2 rounded-lg bg-slate-900 text-white text-sm font-medium hover:bg-slate-700 disabled:opacity-50 transition-colors"
+                          >
+                            {twilioSaving ? 'Saving…' : 'Save'}
+                          </button>
+                          <button
+                            type="button"
+                            disabled={twilioTesting}
+                            onClick={async () => {
+                              setTwilioTesting(true);
+                              setTwilioTestResult(null);
+                              setTwilioTestError('');
+                              try {
+                                await settingsAPI.testTwilio();
+                                setTwilioTestResult('ok');
+                              } catch (err: any) {
+                                setTwilioTestResult('fail');
+                                setTwilioTestError(err?.response?.data?.error ?? 'Unknown error');
+                              } finally {
+                                setTwilioTesting(false);
+                              }
+                            }}
+                            className="px-4 py-2 rounded-lg border border-slate-200 text-slate-700 text-sm font-medium hover:bg-slate-50 disabled:opacity-50 transition-colors"
+                          >
+                            {twilioTesting ? 'Testing…' : 'Test credentials'}
+                          </button>
+                        </div>
+
+                        {/* Send test SMS */}
+                        <div className="pt-3 border-t border-slate-100">
+                          <p className="text-xs font-medium text-slate-600 mb-2">Send a test SMS</p>
+                          <div className="flex gap-2">
+                            <input
+                              type="tel"
+                              value={twilioTestPhone}
+                              onChange={(e) => { setTwilioTestPhone(e.target.value); setTwilioSendTestResult(null); }}
+                              placeholder="+447700900001"
+                              className="flex-1 px-3 py-2 rounded-lg border border-slate-200 text-sm bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:bg-white transition-all"
+                            />
+                            <button
+                              type="button"
+                              disabled={twilioSendingTest || !twilioTestPhone.trim()}
+                              onClick={async () => {
+                                setTwilioSendingTest(true);
+                                setTwilioSendTestResult(null);
+                                setTwilioSendTestError('');
+                                try {
+                                  await settingsAPI.sendTestSms(twilioTestPhone.trim());
+                                  setTwilioSendTestResult('ok');
+                                } catch (err: any) {
+                                  setTwilioSendTestResult('fail');
+                                  setTwilioSendTestError(err?.response?.data?.error ?? 'Unknown error');
+                                } finally {
+                                  setTwilioSendingTest(false);
+                                }
+                              }}
+                              className="px-4 py-2 rounded-lg border border-slate-200 text-slate-700 text-sm font-medium hover:bg-slate-50 disabled:opacity-50 transition-colors whitespace-nowrap"
+                            >
+                              {twilioSendingTest ? 'Sending…' : 'Send'}
+                            </button>
+                          </div>
+                          {twilioSendTestResult === 'ok' && <p className="text-xs text-emerald-600 mt-1.5">Test SMS sent — check your phone.</p>}
+                          {twilioSendTestResult === 'fail' && <p className="text-xs text-red-600 mt-1.5">{twilioSendTestError}</p>}
+                          <p className="text-xs text-slate-400 mt-1">Number must be in E.164 format, e.g. +447700900001</p>
+                        </div>
+                      </form>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,6 +15,11 @@ JWT_SECRET=change_this_to_a_long_random_string
 ENCRYPT_RESPONSES=true
 API_ENCRYPTION_KEY=generate_with_node_crypto_randomBytes_32_hex
 
+# Twilio SMS — leave blank to fall back to console logging in development
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_FROM=+1234567890
+
 # Email (Nodemailer) — leave blank to disable email delivery in development
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587

--- a/server/src/controllers/familyController.ts
+++ b/server/src/controllers/familyController.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { Op } from 'sequelize';
 import crypto from 'crypto';
 import { Visit, FamilyContact, FamilyToken, Patient, Stage } from '../models';
-import { sendOTPEmail } from '../lib/mailer';
+import { sendOTPEmail, sendOTPSms } from '../lib/mailer';
 
 // Helper to generate 6-digit OTP
 const generateOTP = (): string => {
@@ -145,10 +145,9 @@ export const requestOTP = async (req: Request, res: Response) => {
 
     const recipientEmail = familyContact.email;
     if (recipientEmail) {
-      await sendOTPEmail(recipientEmail, otp, 'your relative');
+      await sendOTPEmail(recipientEmail, otp, familyContact.name);
     } else {
-      // SMS not yet integrated
-      console.log(`[DEV] OTP SMS to ${familyContact.phone}: ${otp}`);
+      await sendOTPSms(familyContact.phone, otp, familyContact.name);
     }
 
     const maskedRecipient = recipientEmail

--- a/server/src/lib/mailer.ts
+++ b/server/src/lib/mailer.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import { Resend } from 'resend';
+import twilio from 'twilio';
 import { SystemSetting } from '../models/SystemSetting';
 
 async function getResendClient(): Promise<{ client: Resend; from: string } | null> {
@@ -83,6 +84,35 @@ export const sendOTPEmail = async (
 
   // Neither configured — log for dev
   console.log(`[DEV] OTP email to ${to}: ${otp}`);
+};
+
+async function getTwilioClient(): Promise<{ client: twilio.Twilio; from: string } | null> {
+  try {
+    const rows = await SystemSetting.findAll({ where: { key: ['twilio_account_sid', 'twilio_auth_token', 'twilio_from'] } });
+    const db: Record<string, string> = {};
+    for (const row of rows) { if (row.value) db[row.key] = row.value; }
+    const sid   = db['twilio_account_sid'] ?? process.env.TWILIO_ACCOUNT_SID ?? '';
+    const token = db['twilio_auth_token']  ?? process.env.TWILIO_AUTH_TOKEN  ?? '';
+    const from  = db['twilio_from']        ?? process.env.TWILIO_FROM        ?? '';
+    if (!sid || !token || !from) return null;
+    return { client: twilio(sid, token), from };
+  } catch { return null; }
+}
+
+export const sendOTPSms = async (
+  to: string,
+  otp: string,
+  patientFirstName: string
+): Promise<void> => {
+  const body = `Your OR Tracker access code is: ${otp}\n\nThis code lets you check on ${patientFirstName}'s progress and expires in 15 minutes.`;
+
+  const tw = await getTwilioClient();
+  if (tw) {
+    await tw.client.messages.create({ from: tw.from, to, body });
+    return;
+  }
+
+  console.log(`[DEV] OTP SMS to ${to}: ${otp}`);
 };
 
 export const sendCredentialsEmail = async (

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import nodemailer from 'nodemailer';
 import { Resend } from 'resend';
+import twilio from 'twilio';
 import { authenticate } from '../middleware/auth';
 import { SystemSetting } from '../models/SystemSetting';
 
@@ -196,6 +197,97 @@ router.post('/resend/send-test', authenticate, async (req: Request, res: Respons
       html: '<div style="font-family:sans-serif;padding:24px"><p>This is a test email from your <strong>OR Patient Tracking System</strong>.</p><p>Email notifications are working correctly.</p></div>',
     });
     if (error) throw new Error((error as any).message ?? JSON.stringify(error));
+    res.json({ success: true });
+  } catch (err: any) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+});
+
+// GET /api/settings/twilio
+router.get('/twilio', authenticate, async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+
+  const rows = await SystemSetting.findAll({ where: { key: ['twilio_account_sid', 'twilio_auth_token', 'twilio_from'] } });
+  const db: Record<string, string> = {};
+  for (const row of rows) { if (row.value !== null) db[row.key] = row.value; }
+
+  res.json({
+    success: true,
+    config: {
+      twilio_account_sid: db['twilio_account_sid'] ?? '',
+      twilio_auth_token:  db['twilio_auth_token']  ? PASS_PLACEHOLDER : '',
+      twilio_from:        db['twilio_from']        ?? '',
+    },
+  });
+});
+
+// PUT /api/settings/twilio
+router.put('/twilio', authenticate, async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+
+  const { twilio_account_sid, twilio_auth_token, twilio_from } = req.body;
+
+  if (twilio_account_sid !== undefined)
+    await SystemSetting.upsert({ key: 'twilio_account_sid', value: String(twilio_account_sid).trim() });
+  if (twilio_from !== undefined)
+    await SystemSetting.upsert({ key: 'twilio_from', value: String(twilio_from).trim() });
+  if (twilio_auth_token !== undefined && twilio_auth_token !== PASS_PLACEHOLDER && twilio_auth_token !== '')
+    await SystemSetting.upsert({ key: 'twilio_auth_token', value: String(twilio_auth_token).trim() });
+
+  res.json({ success: true });
+});
+
+// POST /api/settings/twilio/test — validate credentials by listing Twilio account
+router.post('/twilio/test', authenticate, async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+
+  const rows = await SystemSetting.findAll({ where: { key: ['twilio_account_sid', 'twilio_auth_token', 'twilio_from'] } });
+  const db: Record<string, string> = {};
+  for (const row of rows) { if (row.value) db[row.key] = row.value; }
+
+  const sid   = db['twilio_account_sid'] ?? process.env.TWILIO_ACCOUNT_SID ?? '';
+  const token = db['twilio_auth_token']  ?? process.env.TWILIO_AUTH_TOKEN  ?? '';
+  const from  = db['twilio_from']        ?? process.env.TWILIO_FROM        ?? '';
+
+  if (!sid || !token || !from) {
+    return res.status(400).json({ success: false, error: 'Twilio config is incomplete (SID, auth token, and from number required)' });
+  }
+
+  try {
+    const client = twilio(sid, token);
+    await client.api.accounts(sid).fetch();
+    res.json({ success: true });
+  } catch (err: any) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+});
+
+// POST /api/settings/twilio/send-test — send a test SMS to a given number
+router.post('/twilio/send-test', authenticate, async (req: Request, res: Response) => {
+  if (!requireAdmin(req, res)) return;
+
+  const { to } = req.body;
+  if (!to) return res.status(400).json({ success: false, error: 'to phone number is required' });
+
+  const rows = await SystemSetting.findAll({ where: { key: ['twilio_account_sid', 'twilio_auth_token', 'twilio_from'] } });
+  const db: Record<string, string> = {};
+  for (const row of rows) { if (row.value) db[row.key] = row.value; }
+
+  const sid   = db['twilio_account_sid'] ?? process.env.TWILIO_ACCOUNT_SID ?? '';
+  const token = db['twilio_auth_token']  ?? process.env.TWILIO_AUTH_TOKEN  ?? '';
+  const from  = db['twilio_from']        ?? process.env.TWILIO_FROM        ?? '';
+
+  if (!sid || !token || !from) {
+    return res.status(400).json({ success: false, error: 'Twilio config is incomplete' });
+  }
+
+  try {
+    const client = twilio(sid, token);
+    await client.messages.create({
+      from,
+      to,
+      body: 'This is a test message from your OR Patient Tracking System. SMS notifications are working correctly.',
+    });
     res.json({ success: true });
   } catch (err: any) {
     res.status(400).json({ success: false, error: err.message });


### PR DESCRIPTION
- Install twilio package and wire sendOTPSms into family OTP flow
- Add getTwilioClient helper reading credentials from system_settings or env
- Add /api/settings/twilio GET, PUT, test, send-test endpoints
- Add Twilio config form in admin settings UI with save, test, and send test SMS
- Update Postman collection with Twilio settings and health check endpoints
- Add TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM to .env.example